### PR TITLE
Fix name of config file that is read.

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@ import ConfigParser
 import ast
 
 config = ConfigParser.RawConfigParser()
-config.read('test.cfg')
+config.read('example.cfg')
 
 # single variables
 print config.get('section1', 'var1')


### PR DESCRIPTION
Just a minor fix so that the example doesn't break with the wrong config file name.
